### PR TITLE
feat(ST-3451): add timeout settings to prevent stuck connections

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,4 +13,4 @@ jobs:
       - name: Build image and run tests
         run: |
           docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
-          docker-compose run ci
+          docker compose run ci

--- a/src/Common.php
+++ b/src/Common.php
@@ -48,10 +48,6 @@ class Common
                 'handler' => $handlerStack,
                 'connect_timeout' => 120,
                 'timeout' => 120,
-                'curl' => [
-                    CURLOPT_TCP_KEEPIDLE => 60,
-                    CURLOPT_TCP_KEEPINTVL => 30,
-                ],
             ],
         );
     }

--- a/src/Common.php
+++ b/src/Common.php
@@ -46,6 +46,15 @@ class Common
                     self::DEFAULT_HEADERS,
                 ),
                 'handler' => $handlerStack,
+                'connect_timeout' => 120,
+                'timeout' => 120,
+                'curl' => [
+                    CURLOPT_LOW_SPEED_LIMIT => 1,
+                    CURLOPT_LOW_SPEED_TIME => 120,
+                    CURLOPT_TCP_KEEPALIVE => 1,
+                    CURLOPT_TCP_KEEPIDLE => 60,
+                    CURLOPT_TCP_KEEPINTVL => 30,
+                ],
             ],
         );
     }

--- a/src/Common.php
+++ b/src/Common.php
@@ -49,9 +49,6 @@ class Common
                 'connect_timeout' => 120,
                 'timeout' => 120,
                 'curl' => [
-                    CURLOPT_LOW_SPEED_LIMIT => 1,
-                    CURLOPT_LOW_SPEED_TIME => 120,
-                    CURLOPT_TCP_KEEPALIVE => 1,
                     CURLOPT_TCP_KEEPIDLE => 60,
                     CURLOPT_TCP_KEEPINTVL => 30,
                 ],


### PR DESCRIPTION
## Summary
Add basic timeout settings to the Guzzle HTTP client to prevent infinite hangs from stale connections in the OAuth API client. This addresses a root cause analysis of a 36-hour stuck connection in job runner where curl_multi_poll() was waiting forever on a half-closed TCP connection.

Changes:
- `connect_timeout`: 120 seconds for initial connection establishment
- `timeout`: 120 seconds for total request duration
- Minor CI fix: `docker-compose` -> `docker compose`

## Updates since last revision
Removed all curl options (`CURLOPT_LOW_SPEED_LIMIT`, `CURLOPT_LOW_SPEED_TIME`, `CURLOPT_TCP_KEEPALIVE`, `CURLOPT_TCP_KEEPIDLE`, `CURLOPT_TCP_KEEPINTVL`) per review feedback. The PR now only adds the basic Guzzle timeout settings.

## Change type
Bug fix / Hardening

## Justification
Prevents potential infinite hangs when connections to the OAuth service stall due to network issues, half-closed TCP connections, or server-side idle timeouts.

Linear: ST-3451

## Deployment
Merge & automatic deploy.

## Rollback plan
Revert of this PR.

## Post release support plan
Observe behavior in https://keboolaglobal.slack.com/archives/C0A6VUQRNCS

## Review & Testing Checklist for Human
- [ ] Confirm the 120-second timeout values are appropriate for OAuth API response times (these match values used in storage-api-php-client)
- [ ] Verify no OAuth operations legitimately take longer than 120 seconds

### Notes
Requested by @ondrejhlavacek

Link to Devin run: https://app.devin.ai/sessions/b9af62264edc45008bca3649e5d6a9c8